### PR TITLE
utility additions to ImmediateValuePromise

### DIFF
--- a/src/immediatevalue.rs
+++ b/src/immediatevalue.rs
@@ -231,6 +231,18 @@ impl<T: Send + 'static> ImmediateValuePromise<T> {
     }
 }
 
+impl<T, V> From<T> for ImmediateValuePromise<V> 
+where
+    T: Future<Output = V> + Send + 'static,
+    V: Send + 'static
+{
+    fn from(value: T) -> Self {
+        ImmediateValuePromise::new(async move {
+            Ok(value.await)
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::fs::File;

--- a/src/immediatevalueprogress.rs
+++ b/src/immediatevalueprogress.rs
@@ -1,4 +1,4 @@
-use crate::{DirectCacheAccess, Progress};
+use crate::{BoxedSendError, DirectCacheAccess, Progress};
 use crate::{ImmediateValuePromise, ImmediateValueState};
 use std::borrow::Cow;
 use std::time::Instant;
@@ -132,15 +132,21 @@ impl<T: Send + 'static, M> ProgressTrackedImValProm<T, M> {
     }
 }
 
-impl<T: Send + 'static, M> DirectCacheAccess<T> for ProgressTrackedImValProm<T, M> {
+impl<T: Send + 'static, M> DirectCacheAccess<T, BoxedSendError> for ProgressTrackedImValProm<T, M> {
     fn get_value_mut(&mut self) -> Option<&mut T> {
         self.promise.get_value_mut()
     }
     fn get_value(&self) -> Option<&T> {
         self.promise.get_value()
     }
+    fn get_result(&self) -> Option<Result<&T, &BoxedSendError>> {
+        self.promise.get_result()
+    }
     fn take_value(&mut self) -> Option<T> {
         self.promise.take_value()
+    }
+    fn take_result(&mut self) -> Option<Result<T, BoxedSendError>> {
+        self.promise.take_result()
     }
 }
 #[cfg(test)]


### PR DESCRIPTION
After using ```lazy_async_promise``` with a lot of success for a while I noticed that these two things would be useful additions to the toolset.

## 1. ```get_result``` and ```take_result``` 

I often find myself working with promises where I wait for them to stop updating after which I wan't to get the success or the error value which is where these functions have come very much in handy.

## 2. ```impl From<T: std::future::Future + Send + 'static>```

This might be personal preference but I dislike the constant wrapping of futures to create ```ImmediateValuePromise```'s so I implemented the the ```From``` trait for ```T: std::future::Future + Send + 'static``` for very easy conversion with ```.into()```.

----

I don't know if this proposal is a bit unsolicited but I much enjoy using this crate and would love to make it even more useful in my eyes. If there are tests I should add or changes I should make feel free to tell me so.